### PR TITLE
Add config to Guardfile options

### DIFF
--- a/lib/guard/goliath/runner.rb
+++ b/lib/guard/goliath/runner.rb
@@ -45,6 +45,7 @@ module Guard
       )
       command << '--daemonize' if options[:daemon]
       command << '-sv' unless options[:supress_output]
+      command.push('--config', options[:config]) if options[:config]
 
       command
     end


### PR DESCRIPTION
Add Guardfile option to set --config option for goliath.

This time only one and correct commit.
